### PR TITLE
entityとrepositoryの作成 #10

### DIFF
--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/Map.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/Map.java
@@ -1,0 +1,76 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * マップのエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Map {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="map_id", nullable=false)
+    Long mapId;   //マップID
+
+    @Column(name="name", nullable=false)
+    String name; // マップ名
+
+    @Column(name="description", nullable=false)
+    String description; // 詳細
+
+    @Column(name="clear_point", nullable=false)
+    int clearPoint; // クリアに必要なポイント
+
+    @Column(name="range_limit", nullable=false)
+    double rangeLimit; // 位置情報の誤差
+
+    @Column(name="present_url", nullable=false)
+    String presentURL; // プレゼント応募ページのURL
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="start_date", nullable=false)
+    Date startDate; // イベントの開始日時
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="end_date", nullable=false)
+    Date endDate; // イベントの終了日時
+
+    @Column(name="is_enabled", nullable=false)
+    boolean isEnabled; // 表示させるかどうか
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="created_at", nullable=false)
+    Date createdAt; // 作成日時
+
+    @Column(name="created_by", nullable=false)
+    Date createdBy; // 作成者
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="updated_at", nullable=false)
+    Date updatedAt; // 最終更新日時
+
+    @Column(name="updated_by", nullable=false)
+    Date updatedBy; // 最終更新者
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="deleted_at", nullable=true)
+    Date deletedAt; // 削除日時
+
+    @Column(name="deleted_by", nullable=true)
+    Date deletedBy; // 削除者
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/Progress.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/Progress.java
@@ -1,0 +1,57 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 進捗のエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Progress {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="progress_id", nullable=false)
+    Long progressId; //進捗ID
+
+    @EmbeddedId
+    @Column(name="map_id", nullable=false)
+    Long mapId; // マップID
+
+    @EmbeddedId
+    @Column(name="user_id", nullable=false)
+    UUID userId; // ユーザID
+
+    @Column(name="score", nullable=false)
+    int score; // スコア
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="created_at", nullable=false)
+    Date createdAt; // 作成日時
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="updated_at", nullable=false)
+    Date updatedAt; // 最終更新日時
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="deleted_at", nullable=true)
+    Date deletedAt; // 削除日時
+
+    @Column(name="deleted_by", nullable=true)
+    Date deletedBy; // 削除者
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/Progress.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/Progress.java
@@ -4,7 +4,6 @@ import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -29,11 +28,9 @@ public class Progress {
     @Column(name="progress_id", nullable=false)
     Long progressId; //進捗ID
 
-    @EmbeddedId
     @Column(name="map_id", nullable=false)
     Long mapId; // マップID
 
-    @EmbeddedId
     @Column(name="user_id", nullable=false)
     UUID userId; // ユーザID
 

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/Spot.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/Spot.java
@@ -1,0 +1,71 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * スポットのエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Spot {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="spot_id", nullable=false)
+    Long spotId;   //スポットID
+
+    @Column(name="map_id", nullable=false)
+    Long mapId; // マップID
+
+    @Column(name="name", nullable=false)
+    String name; // スポット名
+
+    @Column(name="description", nullable=false)
+    String description; // 詳細
+
+    @Column(name="latitude", nullable=false)
+    double latitude; // スポットの緯度
+
+    @Column(name="longitude", nullable=false)
+    double longitude; // スポットの経度
+
+    @Column(name="image_url", nullable=false)
+    String imageUrl; // 画像のURL
+
+    @Column(name="is_enabled", nullable=false)
+    boolean isEnabled; // 表示させるかどうか
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="created_at", nullable=false)
+    Date createdAt; // 作成日時
+
+    @Column(name="created_by", nullable=false)
+    Date createdBy; // 作成者
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="updated_at", nullable=false)
+    Date updatedAt; // 最終更新日時
+
+    @Column(name="updated_by", nullable=false)
+    Date updatedBy; // 最終更新者
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="deleted_at", nullable=true)
+    Date deletedAt; // 削除日時
+
+    @Column(name="deleted_by", nullable=true)
+    Date deletedBy; // 削除者
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/SpotLog.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/SpotLog.java
@@ -1,0 +1,47 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * スポットログのエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class SpotLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="spot_log_id", nullable=false)
+    Long spotLogId; //スポットログID
+
+    @EmbeddedId
+    @Column(name="spot_id", nullable=false)
+    Long spotId; // スポットID
+
+    @EmbeddedId
+    @Column(name="user_id", nullable=false)
+    UUID userId; // ユーザID
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="created_at", nullable=false)
+    Date createdAt; // 作成日時
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name="updated_at", nullable=false)
+    Date updatedAt; // 最終更新日時
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/SpotLog.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/SpotLog.java
@@ -4,7 +4,6 @@ import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.Column;
-import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -29,19 +28,13 @@ public class SpotLog {
     @Column(name="spot_log_id", nullable=false)
     Long spotLogId; //スポットログID
 
-    @EmbeddedId
     @Column(name="spot_id", nullable=false)
     Long spotId; // スポットID
 
-    @EmbeddedId
     @Column(name="user_id", nullable=false)
     UUID userId; // ユーザID
 
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name="created_at", nullable=false)
     Date createdAt; // 作成日時
-
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(name="updated_at", nullable=false)
-    Date updatedAt; // 最終更新日時
 }

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/Task.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/Task.java
@@ -1,0 +1,85 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * タスクのエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Task {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="task_id", nullable=false)
+    Long taskId; // タスクID
+
+    @Column(name="spot_id", nullable=false)
+    Long spotId; // スポットID
+
+    @Min(0)
+    @Max(2)
+    @Column(name="type", nullable=false)
+    int type; // タスクの種類 (0:クイズ，1:謎解き，2:立ち寄り)
+
+    @Column(name="title", nullable=false)
+    String title; // タイトル
+
+    @Column(name="description", nullable=false)
+    String description; // 詳細
+
+    @Column(name="image_url", nullable=false)
+    String imageUrl; // 画像のURL
+
+    @Column(name="answer", nullable=true)
+    String answer; // 答え
+
+    @Column(name="explanation", nullable=true)
+    String explanation; // 解説
+
+    @Column(name="hint", nullable=true)
+    String hint; // ヒント
+
+    @Column(name="option1", nullable=true)
+    String option1; // 選択肢1
+
+    @Column(name="option2", nullable=true)
+    String option2; // 選択肢2
+
+    @Column(name="option3", nullable=true)
+    String option3; // 選択肢3
+
+    @Column(name="is_enabled", nullable=false)
+    boolean isEnabled; // 表示させるかどうか
+
+    @Column(name="created_at", nullable=false)
+    Date createdAt; // 作成日時
+
+    @Column(name="created_by", nullable=false)
+    Date createdBy; // 作成者
+    
+    @Column(name="updated_at", nullable=false)
+    Date updatedAt; // 最終更新日時
+
+    @Column(name="updated_by", nullable=false)
+    Date updatedBy; // 最終更新者
+
+    @Column(name="deleted_at", nullable=true)
+    Date deletedAt; // 削除日時
+
+    @Column(name="deleted_by", nullable=true)
+    Date deletedBy; // 削除者
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/TaskLog.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/TaskLog.java
@@ -43,7 +43,4 @@ public class TaskLog {
     @Column(name = "created_at", nullable = false)
     @Temporal(TemporalType.TIMESTAMP)
     Date createdAt; // 作成日時
-
-    @Column(name = "created_by", nullable = false)
-    String createdBy; // 作成者
 }

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/TaskLog.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/TaskLog.java
@@ -1,0 +1,49 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * タスクログのエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class TaskLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "task_log_id", nullable = false)
+    Long taskLogId; // タスクログID
+
+    @Column(name = "task_id", nullable = false)
+    Long taskId; // タスクID
+
+    @Column(name = "user_id", nullable = false)
+    UUID userId; // ユーザID
+    
+    @Column(name = "is_correct", nullable = true)
+    Boolean isCorrect; // 正解フラグ
+
+    @Column(name = "answer", nullable = true)
+    String answer; // 回答
+
+    @Column(name = "created_at", nullable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    Date createdAt; // 作成日時
+
+    @Column(name = "created_by", nullable = false)
+    String createdBy; // 作成者
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/entity/User.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/entity/User.java
@@ -1,0 +1,62 @@
+package jp.kobespiral.santasandastamprally.entity;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * ユーザのエンティティ
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class User {
+    @Column(name="user_id", nullable=false)
+    @Id
+    UUID userId;   //ユーザID
+
+    @Column(name="name", nullable=true)
+    @NotBlank
+    String name; // 名前
+
+    @Column(name="email", nullable=true)
+    @Email
+    String email; // E-mail
+
+    @Column(name="last_login_at", nullable=false)
+    @Temporal(TemporalType.TIMESTAMP)
+    Date lastLoginAt; // 最終ログイン日時
+
+    @Column(name="created_at", nullable=false)
+    @Temporal(TemporalType.TIMESTAMP)
+    Date createdAt; // 作成日時
+
+    @Column(name="created_by", nullable=false)
+    Date createdBy; // 作成者
+
+    @Column(name="updated_at", nullable=true)
+    @Temporal(TemporalType.TIMESTAMP)
+    Date updatedAt; // 最終更新日時
+
+    @Column(name="updated_by", nullable=false)
+    Date updatedBy; // 最終更新者
+
+    @Column(name="deleted_at", nullable=true)
+    @Temporal(TemporalType.TIMESTAMP)
+    Date deletedAt; // 削除日時
+
+    @Column(name="deleted_by", nullable=true)
+    Date deletedBy; // 削除者
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/MapRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/MapRepository.java
@@ -1,0 +1,16 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.Map;
+
+@Repository
+public interface MapRepository extends CrudRepository<Map, Long> {
+    // すべてのマップを取得
+    List<Map> findAll();
+    // すべての表示するマップを取得
+    List<Map> findByIsEnabled(boolean isEnabled);
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/MapRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/MapRepository.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.Map;
 
+/**
+ * マップのリポジトリ
+ */
 @Repository
 public interface MapRepository extends CrudRepository<Map, Long> {
     // すべてのマップを取得

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/ProgressRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/ProgressRepository.java
@@ -18,5 +18,7 @@ public interface ProgressRepository extends CrudRepository<Progress, Long> {
     // 指定したユーザの，すべての進捗を取得
     List<Progress> findByUserId(UUID userId);
     // 指定したマップの，すべての進捗を取得
-    List<Progress> findByMapId(Long MapId);
+    List<Progress> findByMapId(Long mapId);
+    // 指定したユーザの，指定したマップの進捗を取得
+    Progress findByUserIdAndMapId(UUID userId, Long mapId);
 }

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/ProgressRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/ProgressRepository.java
@@ -1,0 +1,19 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.Progress;
+
+@Repository
+public interface ProgressRepository extends CrudRepository<Progress, Long> {
+    // すべての進捗を取得
+    List<Progress> findAll();
+    // 指定したユーザの，すべての進捗を取得
+    List<Progress> findByUserId(UUID userId);
+    // 指定したマップの，すべての進捗を取得
+    List<Progress> findByMapId(Long MapId);
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/ProgressRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/ProgressRepository.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.Progress;
 
+/**
+ * 進捗のリポジトリ
+ */
 @Repository
 public interface ProgressRepository extends CrudRepository<Progress, Long> {
     // すべての進捗を取得

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotLogRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotLogRepository.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.SpotLog;
 
+/**
+ * スポットログのリポジトリ
+ */
 @Repository
 public interface SpotLogRepository extends CrudRepository<SpotLog, Long> {
     // すべてのスポットログを取得

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotLogRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotLogRepository.java
@@ -1,0 +1,19 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.SpotLog;
+
+@Repository
+public interface SpotLogRepository extends CrudRepository<SpotLog, Long> {
+    // すべてのスポットログを取得
+    List<SpotLog> findAll();
+    // 指定したスポットの，すべてのスポットログを取得
+    List<SpotLog> findBySpotId(Long spotId);
+    // 指定したユーザの，すべてのスポットログを取得
+    List<SpotLog> findByUserId(UUID userId);
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotRepository.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.Spot;
 
+/**
+ * スポットのリポジトリ
+ */
 @Repository
 public interface SpotRepository extends CrudRepository<Spot, Long> {
     // すべてのスポットを取得

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/SpotRepository.java
@@ -1,0 +1,20 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.Spot;
+
+@Repository
+public interface SpotRepository extends CrudRepository<Spot, Long> {
+    // すべてのスポットを取得
+    List<Spot> findAll();
+    // 指定したマップの，すべてのスポットを取得
+    List<Spot> findByMapId(Long mapId);
+    // すべての表示するスポットを取得
+    List<Spot> findByIsEnabled(boolean isEnabled);
+    // 指定したマップの，すべての表示するスポットを取得
+    List<Spot> findByMapIdAndIsEnabled(Long mapId, boolean isEnabled);
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskLogRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskLogRepository.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.TaskLog;
 
+/**
+ * タスクログのリポジトリ
+ */
 @Repository
 public interface TaskLogRepository extends CrudRepository<TaskLog, Long> {
     // すべてのタスクログを取得

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskLogRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskLogRepository.java
@@ -1,0 +1,21 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.TaskLog;
+
+@Repository
+public interface TaskLogRepository extends CrudRepository<TaskLog, Long> {
+    // すべてのタスクログを取得
+    List<TaskLog> findAll();
+    // 指定したタスクの，すべてのタスクログを取得
+    List<TaskLog> findByTaskId(Long taskId);
+    // 指定したユーザの，すべてのタスクログを取得
+    List<TaskLog> findByUserId(UUID userId);
+    // 指定したユーザの，すべての達成したタスクのタスクログを取得
+    List<TaskLog> findByUserIdAndIsCorrect(UUID userId, boolean isCorrect);
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskRepository.java
@@ -1,0 +1,20 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.Task;
+
+@Repository
+public interface TaskRepository extends CrudRepository<Task, Long> {
+    // すべてのタスクを取得
+    List<Task> findAll();
+    // 指定したスポットの，すべてのタスクを取得
+    List<Task> findBySpotId(Long spotId);
+    // すべての表示するタスクを取得
+    List<Task> findByIsEnabled(boolean isEnabled);
+    // 指定したスポットの，すべての表示するタスクを取得
+    List<Task> findBySpotIdAndIsEnabled(Long spotId, boolean isEnabled);
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/TaskRepository.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.Task;
 
+/**
+ * タスクのリポジトリ
+ */
 @Repository
 public interface TaskRepository extends CrudRepository<Task, Long> {
     // すべてのタスクを取得

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/UserRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package jp.kobespiral.santasandastamprally.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import jp.kobespiral.santasandastamprally.entity.User;
+
+@Repository
+public interface UserRepository extends CrudRepository<User, UUID> {
+    // すべてのユーザを取得
+    List<User> findAll();
+}

--- a/src/main/java/jp/kobespiral/santasandastamprally/repository/UserRepository.java
+++ b/src/main/java/jp/kobespiral/santasandastamprally/repository/UserRepository.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import jp.kobespiral.santasandastamprally.entity.User;
 
+/**
+ * ユーザのリポジトリ
+ */
 @Repository
 public interface UserRepository extends CrudRepository<User, UUID> {
     // すべてのユーザを取得


### PR DESCRIPTION
## Issue

\#10

## 概要
### エンティティとリポジトリを作成しました．
### 変更点が3つあるので，以下に記します．
- Quiz・Mystery・Visitを削除し，すべてTaskとして扱うようにしました．\
Taskにint型のtype属性を持たせ，これが0ならクイズ，1なら謎解き，2なら立ち寄りとしました．\
すべてのタスクに共通する属性以外はnullでもいいようにしているので，サービス側でtypeごとに必要な属性が抜けないように処理をしてください．
- SpotLogについて，同じユーザが同じスポットに複数回訪れた時，ログを更新するのではなく追加するように変更しました．
- Taskログから作成者の属性を削除しました．

## PR 作成時のチェック項目

- [x] PR 名は issue 名と同じにした
- [x] 担当者として Assignees を設定した
- [x] レビューを希望する人に Reviewers を設定した
- [x] Labels から "PR: Main" ラベルを選択した
